### PR TITLE
0.8.1: Enable code completion by default

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,18 @@
 vscode-php-phan NEWS
 ====================
 
+### 0.8.1 (2019-01-14)
+
+- Enable Code completion support by default. To disable it, set `phan.enableCompletion` to `false`.
+
+  Also see [VS Code's documentation for IntelliSense](https://code.visualstudio.com/docs/editor/intellisense#_customizing-intellisense)
+  for how to control when/how suggestions show up.
+- Show type signatures in hover text for internal functions/methods.
+
+  Also use PHPDoc when rendering type signatures for user-defined functions/methods.
+- Fix variable completion of `$` followed by nothing
+- See [Phan's NEWS](https://github.com/phan/phan/blob/a276d601436cc94c62578b3ddad0a88540966ae4/NEWS.md) for more details.
+
 ### 0.8.0 (2019-01-12)
 
 - Enable Code completion support by default. To disable it, set `phan.enableCompletion` to `false`.

--- a/README.md
+++ b/README.md
@@ -120,16 +120,26 @@ See [VS Code's documentation of Intellisense](https://code.visualstudio.com/docs
 See [VS Code's documentation of IntelliSense configuration](https://code.visualstudio.com/docs/editor/intellisense#_customizing-intellisense)
 for how to control when/how suggestions show up.
 
+You may want to disable VS Code's built-in IntelliSense for PHP by setting `php.suggest.basic` to `false`, to avoid duplicate suggestions.
+
 ## Contributing
 
 ## Release History
 
-### 0.8.0 (2019-01-12)
+### 0.8.1 (2019-01-14)
 
 - Enable Code completion support by default. To disable it, set `phan.enableCompletion` to `false`.
 
   Also see [VS Code's documentation for IntelliSense](https://code.visualstudio.com/docs/editor/intellisense#_customizing-intellisense)
   for how to control when/how suggestions show up.
+- Show type signatures in hover text for internal functions/methods.
+
+  Also use PHPDoc when rendering type signatures for user-defined functions/methods.
+- Fix variable completion of `$` followed by nothing
+- See [Phan's NEWS](https://github.com/phan/phan/blob/a276d601436cc94c62578b3ddad0a88540966ae4/NEWS.md) for more details.
+
+### 0.8.0 (2019-01-12)
+
 - Enable error tolerant parsing by default.
 - Enable the fallback parser by default (required by code completion)
 - Fix a bug in code completion for variables and static properties.

--- a/composer.json
+++ b/composer.json
@@ -8,6 +8,6 @@
     },
     "require": {
         "php": "^7.0.0",
-        "phan/phan": "dev-master#9fd40ca04d49888b51de5dc8045a92789fcd3feb"
+        "phan/phan": "dev-master#a276d601436cc94c62578b3ddad0a88540966ae4"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0f7392d9345f4f91a7327c8abc3fc87f",
+    "content-hash": "99f2c186f6cf59459eb8edbd8b9d9167",
     "packages": [
         {
             "name": "composer/semver",
@@ -155,16 +155,16 @@
         },
         {
             "name": "microsoft/tolerant-php-parser",
-            "version": "v0.0.15",
+            "version": "v0.0.16",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Microsoft/tolerant-php-parser.git",
-                "reference": "54a84f1250dcde5641e86b5e966fec5f0e201f71"
+                "reference": "b662587eb797685a98239d1d52d25168a03fdfb2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Microsoft/tolerant-php-parser/zipball/54a84f1250dcde5641e86b5e966fec5f0e201f71",
-                "reference": "54a84f1250dcde5641e86b5e966fec5f0e201f71",
+                "url": "https://api.github.com/repos/Microsoft/tolerant-php-parser/zipball/b662587eb797685a98239d1d52d25168a03fdfb2",
+                "reference": "b662587eb797685a98239d1d52d25168a03fdfb2",
                 "shasum": ""
             },
             "require": {
@@ -192,7 +192,7 @@
                 }
             ],
             "description": "Tolerant PHP-to-AST parser designed for IDE usage scenarios",
-            "time": "2018-09-26T05:43:26+00:00"
+            "time": "2018-12-29T00:31:32+00:00"
         },
         {
             "name": "netresearch/jsonmapper",
@@ -242,12 +242,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/phan/phan.git",
-                "reference": "9fd40ca04d49888b51de5dc8045a92789fcd3feb"
+                "reference": "a276d601436cc94c62578b3ddad0a88540966ae4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phan/phan/zipball/9fd40ca04d49888b51de5dc8045a92789fcd3feb",
-                "reference": "9fd40ca04d49888b51de5dc8045a92789fcd3feb",
+                "url": "https://api.github.com/repos/phan/phan/zipball/a276d601436cc94c62578b3ddad0a88540966ae4",
+                "reference": "a276d601436cc94c62578b3ddad0a88540966ae4",
                 "shasum": ""
             },
             "require": {
@@ -256,7 +256,7 @@
                 "ext-filter": "*",
                 "ext-json": "*",
                 "felixfbecker/advanced-json-rpc": "^3.0.3",
-                "microsoft/tolerant-php-parser": "0.0.15",
+                "microsoft/tolerant-php-parser": "0.0.16",
                 "php": "^7.0.0",
                 "sabre/event": "^5.0",
                 "symfony/console": "^2.3|^3.0|~4.0"
@@ -300,7 +300,7 @@
                 "php",
                 "static"
             ],
-            "time": "2019-01-12T17:33:47+00:00"
+            "time": "2019-01-15T00:11:38+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "php-phan",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "private": true,
   "preview": false,
-  "version": "0.8.0",
+  "version": "0.8.1",
   "engines": {
     "vscode": "^1.30.0",
     "os": [
@@ -105,7 +105,7 @@
         },
         "phan.enableCompletion": {
           "type": "boolean",
-          "default": false,
+          "default": true,
           "markdownDescription": "If enabled, Phan supports \"Completion\" requests. This may conflict with \"PHP IntelliSense\". (Disabled by default)."
         },
         "phan.analyzedFileExtensions": {


### PR DESCRIPTION
This was accidentally left out of the release.

Also, fix completion of `$` followed by nothing

For #50