### PR TITLE
Add "Restart Phan Language Server" command

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,13 @@
     "vscode-languageclient": "^6.1.4"
   },
   "contributes": {
+    "commands": [
+      {
+        "command": "phan.restartLanguageServer",
+        "title": "Restart Phan Language Server",
+        "category": "Phan"
+      }
+    ],
     "configuration": {
       "type": "object",
       "title": "PHP - Phan Analyzer",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -430,11 +430,17 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
         return new LanguageClient('Phan Language Server', serverOptions, clientOptions);
     };
 
+    const languageClients = analyzedProjectDirectories.map(createClient);
+
+    function restartLanguageClients() {
+        return Promise.all(languageClients.map((c: LanguageClient) => c.stop().then(() => c.start())));
+    }
+    context.subscriptions.push(vscode.commands.registerCommand('phan.restartLanguageServer', restartLanguageClients));
+
     console.log('starting PHP Phan language server');
-    // Create the language client and start the client.
-    for (const dirToAnalyze of analyzedProjectDirectories) {
+    for (const client of languageClients) {
         // Push the disposable to the context's subscriptions so that the
         // client can be deactivated on extension deactivation
-        context.subscriptions.push(createClient(dirToAnalyze).start());
+        context.subscriptions.push(client.start());
     }
 }


### PR DESCRIPTION
On my Windows machine, the language server seems to run into issues regularly. Rather than implement a proper solution, I went ahead and added a command to restart the LSP server in the time-honored tradition of, "It's Windows; just restart it".

I haven't fully tested this out yet, but it seems to at least kinda work.